### PR TITLE
Added allow_interline_swaps setting

### DIFF
--- a/lua/sibling-swap/settings.lua
+++ b/lua/sibling-swap/settings.lua
@@ -57,6 +57,7 @@ local DEFAUTL_SETTINGS = {
     ['<space>,'] = 'swap_with_left_with_opp',
   },
   ignore_injected_langs = false,
+  allow_interline_swaps = false,
 }
 
 M.settings = DEFAUTL_SETTINGS

--- a/lua/sibling-swap/utils.lua
+++ b/lua/sibling-swap/utils.lua
@@ -64,7 +64,7 @@ local function is_suitable_nodes(node, named_sibling, sibling)
   return check_siblings(node, named_sibling)
     and (
       (is_space_between_allowed and has_space_between(node, named_sibling))
-      or is_allowed_sep(named_sibling)
+      or is_allowed_sep(sibling)
     )
 end
 

--- a/lua/sibling-swap/utils.lua
+++ b/lua/sibling-swap/utils.lua
@@ -62,7 +62,13 @@ local function is_suitable_nodes(node, named_sibling, sibling)
   local checked = check_siblings(node, named_sibling)
 
   if not has_unnamed(named_sibling, sibling) then
-    return checked and ((is_siblings_on_same_line(node, named_sibling) and has_space_between(node, named_sibling)) or is_allowed_sep(named_sibling))
+    return checked
+      and (
+        (
+          is_siblings_on_same_line(node, named_sibling)
+          and has_space_between(node, named_sibling)
+        ) or is_allowed_sep(named_sibling)
+      )
   else
     return checked and is_allowed_sep(sibling)
   end
@@ -127,7 +133,8 @@ function M.calc_cursor(repl, side)
   local actual_left_range = repl[1].range
 
   if side == LEFT then
-    local pos_in_node = {cursor[1] - actual_right_range[1], cursor[2] - actual_right_range[2]}
+    local pos_in_node =
+      { cursor[1] - actual_right_range[1], cursor[2] - actual_right_range[2] }
     cursor[2] = pos_in_node[2] + actual_left_range[2]
     cursor[1] = pos_in_node[1] + actual_left_range[1]
   else

--- a/lua/sibling-swap/utils.lua
+++ b/lua/sibling-swap/utils.lua
@@ -59,19 +59,13 @@ local function is_suitable_nodes(node, named_sibling, sibling)
     return false
   end
 
-  local checked = check_siblings(node, named_sibling)
-
-  if not has_unnamed(named_sibling, sibling) then
-    return checked
-      and (
-        (
-          is_siblings_on_same_line(node, named_sibling)
-          and has_space_between(node, named_sibling)
-        ) or is_allowed_sep(named_sibling)
-      )
-  else
-    return checked and is_allowed_sep(sibling)
-  end
+  local is_space_between_allowed = not has_unnamed(named_sibling, sibling)
+    and is_siblings_on_same_line(node, named_sibling)
+  return check_siblings(node, named_sibling)
+    and (
+      (is_space_between_allowed and has_space_between(node, named_sibling))
+      or is_allowed_sep(named_sibling)
+    )
 end
 
 ---Get candidates to swapping


### PR DESCRIPTION
Setting `allow_interline_swaps` to `true` will allow swaps across lines; it is `false` by default.